### PR TITLE
Add support for counted nullary options using std::vector<bool>

### DIFF
--- a/quick_arg_parser.hpp
+++ b/quick_arg_parser.hpp
@@ -568,6 +568,15 @@ protected:
 			return !parent->findOption(name, shortcut).empty();
 		}
 
+		operator std::vector<bool>() const {
+			if (parent->singleton().initialisationState == INITIALISING) {
+				parent->singleton().nullarySwitches.push_back(std::make_pair(name, shortcut));
+				addHelpEntry();
+				return std::vector<bool>();
+			}
+			return std::vector<bool>(parent->findOption(name, shortcut).size(), true);
+		}
+
 		template <typename T>
 		T getOption(T defaultValue) const {
 			if (parent->singleton().initialisationState == INITIALISING) {

--- a/quick_arg_parser_test.cpp
+++ b/quick_arg_parser_test.cpp
@@ -63,6 +63,16 @@ struct Input4 : MainArguments<Input4> {
 	std::string path = argument(0) = ".";
 };
 
+struct Input5 : MainArguments<Input5> {
+	using MainArguments<Input5>::MainArguments; // Not necessary in C++17
+	std::vector<bool> verbose = option("verbose", 'V');
+	bool extra = option("extra", 'e');
+	int port = option("port", 'p');
+	int secondaryPort = option("port2", 'P') = 999;
+	int parts = argument(0) = 1;
+	Optional<int> logPort = option("logPort", 'l');
+};
+
 template <typename T>
 T constructFromString(std::string args) {
 	std::vector<char*> segments;
@@ -132,6 +142,15 @@ int main() {
 	verify(t4.muteNeighbours, true);
 	verify(t4.jamPhones, true);
 	verify(t4.path, "~/Music");
+
+	std::cout << "Fifth input" << std::endl;
+	Input5 t5 = constructFromString<Input5>("super_program -VV -VeVV --port 666 -- 3");
+	verify(t5.verbose.size(), 5);
+	verify(t5.extra, true);
+	verify(t5.port, 666);
+	verify(t5.secondaryPort, 999);
+	verify(t5.parts, 3);
+	verify(bool(t5.logPort), false);
 
 	std::cout << "Errors: " << errors << std::endl;
 }


### PR DESCRIPTION
I thought it would be cool to support counted flag options like the verbosity level flag in Gnu tar. Using the size of a vector<bool> may be a bit heavy-weight, but it's a simple change and leverages your existing vector support.