### PR TITLE
Fix access out of bounds for bool arguments.

### DIFF
--- a/quick_arg_parser.hpp
+++ b/quick_arg_parser.hpp
@@ -573,7 +573,7 @@ private:
 					if (_argv[i].size() > argument.size() && _argv[i][argument.size()] == '=')
 						collected.push_back(_argv[i].substr(argument.size() + 1));
 					else
-						collected.push_back(_argv[i + 1]);
+						collected.push_back(_argv[std::min<int>(i + 1, _argv.size() - 1)]);
 				}
 			}
 		}


### PR DESCRIPTION
When using a long bool argument as last argument, you will push_back a null-pointer which is undefined behavior (and actually crashes for me) see https://en.cppreference.com/w/cpp/string/basic_string/basic_string (5)